### PR TITLE
Build packages using the script in the psycopg2 project

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,38 +11,38 @@ environment:
     global:
         # MSVC Express 2008's setenv.cmd failes if /E:ON and /V:ON are not
         # enabled in the batch script interpreter
-        #
-        #      WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
         CMD_IN_ENV: cmd /E:ON /V:ON /C .\appveyor\run_with_env.cmd
 
     matrix:
         # For Python versions available on Appveyor, see
-        # http://www.appveyor.com/docs/installed-software#python
-      - {PYVER: "27", PYTHON_ARCH: "32"}
-      - {PYVER: "27", PYTHON_ARCH: "64"}
-      - {PYVER: "34", PYTHON_ARCH: "32"}
-      - {PYVER: "34", PYTHON_ARCH: "64"}
-      - {PYVER: "35", PYTHON_ARCH: "32"}
-      - {PYVER: "35", PYTHON_ARCH: "64"}
-      - {PYVER: "36", PYTHON_ARCH: "32"}
-      - {PYVER: "36", PYTHON_ARCH: "64"}
-      - {PYVER: "37", PYTHON_ARCH: "32"}
-      - {PYVER: "37", PYTHON_ARCH: "64"}
-
+        # https://www.appveyor.com/docs/build-environment/
+      - {PY_VER: "27", PY_ARCH: "32"}
+      - {PY_VER: "27", PY_ARCH: "64"}
+      - {PY_VER: "37", PY_ARCH: "32"}
+      - {PY_VER: "37", PY_ARCH: "64"}
+      - {PY_VER: "36", PY_ARCH: "32"}
+      - {PY_VER: "36", PY_ARCH: "64"}
+      - {PY_VER: "35", PY_ARCH: "32"}
+      - {PY_VER: "35", PY_ARCH: "64"}
+      - {PY_VER: "34", PY_ARCH: "32"}
+      - {PY_VER: "34", PY_ARCH: "64"}
 
     OPENSSL_VERSION: "1_1_1b"
     POSTGRES_VERSION: "11_2"
-    WANT_LIBPQ: 110002
 
     PSYCOPG2_TESTDB: psycopg2_test
     PSYCOPG2_TESTDB_USER: postgres
-    PSYCOPG2_TESTDB_PASSWORD: Password12!
     PSYCOPG2_TESTDB_HOST: localhost
-    PSYCOPG2_TESTDB_PORT: 5432
 
     PGUSER: postgres
     PGPASSWORD: Password12!
     PGSSLMODE: require
+
+    # Select according to the service enabled
+    POSTGRES_DIR: C:\Program Files\PostgreSQL\9.6\
+
+    # The python used in the build process, not the one packages are built for
+    PYEXE: C:\Python36\python.exe
 
     REMOTE_KEY:
         secure: jXJgSVVLKe5wVapVF0GDrbTbbr0cmNamaAkEgNROepTsP4lh7+F3RhD/Quv0jJo13oRNqqeh+MnS6lk2CxEHQePTKKTxDE1AyTGjDHXNh+kBR31W7F6+P7ykwK/aJajUTtSLd0ABe63iD+QP1Pl0iCDHpFrnDPQuiAKzQtTAZTbTMfKxFEVBBtDkP8vAZQgK+iU5JlOeGW/+Zr4QqlTBav1lZrQk3v5pHknl1G33HmgwakNg27JX1IZBjktRzBvWeHCSxeGJDnftzSq2EoDilTYuDWIwRsmLYLsmrvgyrjlEcXu6Ac16cICMOTYrzdxd1c4qiOFyhLoiv17Jh/tm8Ouar4VoBMtxbspm96DuQFTzRGNGOxQ2Ld/xHT9btZ26Ty6YRMVLTsXv/jvpTF3q2ncSC9mmad4jklTTHHPB68KHvm32DfZBCqbMUhwZpYZVbJdW59f8MAXeQY3MBXCdqRtgXX2WbBsek3Yn8DDPgZpGNzPGsqMVJtxuutzoNKQv3GfnVRRC/832EWP/qyvrcRqCiSAB9DgiztWgqyzjtnAFw8gncKQPZCWxDFFSJmctNzPcJb4BrrRzadhTPXDG+hv3gRwOReJXHcSeBcUJdo7gzP+yty87Le20YN0jp4t+s7xQRtre3BWArhm+Nc0VyviPqSWWSdE3yUSJd4N3B2hug8NmsshpDk2xjronx/E423oL+xmMorEenxbsDPr34n3u+rwA8Py6S+rveEupP7QbpRLiVkJqyAgcevw7RnFiwRYaR5q6c/UGJI8fTx2gf7QpstDG2AN0DwpqaP2jCHH8aV441gk3kd97K/FWGkcMNg2mmUL5dt4KpJCwKWcz25YwuZSIzSDJAK3H5W5zdlGdk1bKqZiwn+MWzHYkgv97rJoRMz5bre6IXS+C39Fr7Qv4iAUqgN3Oi06K9kkPytfhHd3nBPQgsVQww4KuRdi7AuXaa3i9EejtPgawdirFKhjSSugXg1x5pQIuqwfSN/hnLkGZB45VLUTP+1XAz48jEbloDZReNyIhYg62cRoHTNs6L8IiwwdYEr8+o4iI9q+PgXrEqMZsZq7XCyFsbupOdlIrprExpmZW6j+mGA001mVD3CefWjSK1LzI+j2WGEsuH6Dr1OxUPNI+Uq8ho/0oDwXqQwIctzj+BbFPnufMxSEZwrHZMxkkautVO+PN5Z7aX4W5F2e1yVN+7J070nqjk8gMvmBcNkOEvyD3ZQt6mBE1yNn2iBdilWd9Q0MZQ5k5rNErEM5tobiArjlkV2pX9ssedPWUrs3JYmnHRbibXoi5AGPGPgNAum4tYO7zEJYIhPFYnCzpxF5R7HYDO8xf5m7F6vvO0YP2GQOIu9x+1OQZYUxWwz6xivYjmcPOUZeQVohirigElXzMOAl0XEnw2YB9BjhC0triybUyaq1v1FUVJMWtD3mIJxrQ2omefa0+T4tdYfYPRXk38CgezO/u/7JDQuGK198T0M6Ufrrw5xsVcmPR+bGAarCeRYtojNq3hEUJeO3z2oZrDE3+IdTysAST2vgtOd+tbm3BQrgcfBPG4dCwnam3apRpIGOY2b+9ugonydHwNTI90/pTtufBMLFtll54cb5McRijTlVYjP+UXmaJMqpxF4T+qlAR2ixLqZu2sPD94TuW6f3MMHLFuT/d6rL2eKcJcX2xlNP6M0gQhsl3gxHPESJzGfFXDRzL/C0RBHePtNoVbr9I4hXKYwya3p8R0GMM7Qe2BD92BDXP5CsH4WpKXqf2h/1gvdVUoiCNMJdk1GQxIof+ap1BJG+uNIUoFd6e5rJoR84Z0dcwvtVliiaFrkK8DhE6hlq38YqabErOFzkTNwdtw1NXv8N6SsIIw57EHcMYgQgpbHzpjHSYnrmLZNrrl1SgV+GQVn6Ep57Oew4XWSvKfRQZk83eDPnO/IDDmq5mtaIwcSfdvUboFLCZpe+C3BYBernHo3UHG4XFsewmL/9/lZH7NiixWHMDDa5BO6JagBQdHKlkjr7nj3jmtQKFvI+CQ+u2f+bDt2MF30I9PwG6QOG7HUONxhz1+ooO9RtcSlBtDshi25uo/heQDF4Z5K/+NtMiDOdylkZ3IlT/EFNP2NNU9c8FTKzOmF4ZC0hlhrMFMOD5gH8pImq0ZhoM+KbgfFc=
@@ -51,8 +51,7 @@ matrix:
     fast_finish: false
 
 services:
-    # Note: if you change this service also change the paths to match
-    # (see where Program Files\Postgres\9.6 is used)
+    # Note: if you change this service also change POSTGRES_DIR
     - postgresql96
 
 cache:
@@ -61,295 +60,43 @@ cache:
   - C:\Others -> appveyor.cache_rebuild
 
 # Script called before repo cloning
-init:
-    # Uncomment next line to get RDP access during the build.
-    #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
-    # Set env variable according to the build environment
-    - SET PYTHON=C:\Python%PYVER%
-    - IF "%PYTHON_ARCH%"=="64" SET PYTHON=%PYTHON%-x64
-
-      # Py 2.7 = VS Ver. 9.0  (VS 2008)
-      # Py 3.3, 3.4 = VS Ver. 10.0 (VS 2010)
-      # Py 3.5, 3.6 = VS Ver. 14.0 (VS 2015)
-    - IF "%PYVER%"=="27" SET VS_VER=9.0
-    - IF "%PYVER%"=="33" SET VS_VER=10.0
-    - IF "%PYVER%"=="34" SET VS_VER=10.0
-    - IF "%PYVER%"=="35" SET VS_VER=14.0
-    - IF "%PYVER%"=="36" SET VS_VER=14.0
-    - IF "%PYVER%"=="37" SET VS_VER=14.0
-
-    - IF "%VS_VER%"=="10.0" IF "%PYTHON_ARCH%"=="64" SET DISTUTILS_USE_SDK=1
-
-    # Set Python to the path
-    - SET PATH=%PYTHON%;%PYTHON%\Scripts;C:\Program Files\Git\mingw64\bin;%PATH%
-
-    # Verify Python version and architecture
-    - ECHO *******************************************************************
-    - ECHO Python Information
-    - ECHO *******************************************************************
-    - "%PYTHON%\\python --version"
-    - "%PYTHON%\\python -c \"import sys; print('64bit: ' + str(sys.maxsize > 2**32))\""
-
-    # Get & Install NASM
-    #- curl -L -o nasminst.exe http://www.nasm.us/pub/nasm/releasebuilds/2.12.02/win64/nasm-2.12.02-installer-x64.exe && start /wait nasminst.exe /S
-    #- SET PATH="C:\Program Files (x86)\nasm;%PATH%"
-
-    # Fix problem with VS2008 Express and 64bit builds
-    - ECHO Fixing VS2008 Express and 64bit builds
-    - COPY "C:\\Program Files (x86)\\Microsoft Visual Studio 9.0\\VC\\bin\\vcvars64.bat" "C:\\Program Files (x86)\\Microsoft Visual Studio 9.0\\VC\\bin\\amd64\\vcvarsamd64.bat"
-
-    # Fix problem with VS2010 Express 64bit missing vcvars64.bat
-    # Note: repository not cloned at this point, so need to fetch
-    # file another way
-    - ECHO Fixing VS2010 Express and 64bit builds
-    - curl -fsSL -o "C:\\Program Files (x86)\\Microsoft Visual Studio 10.0\\VC\\bin\\amd64\\vcvars64.bat" https://raw.githubusercontent.com/psycopg/psycopg2/master/scripts/vcvars64-vs2010.bat
-
-    # Setup the compiler based upon version and architecture
-    - ECHO Configuring Compiler
-    - IF "%PYTHON_ARCH%"=="32" (CALL "C:\\Program Files (x86)\\Microsoft Visual Studio %VS_VER%\\VC\\vcvarsall.bat" x86)
-    - IF "%PYTHON_ARCH%"=="64" (CALL "C:\\Program Files (x86)\\Microsoft Visual Studio %VS_VER%\\VC\\vcvarsall.bat" amd64)
-
-    # The program rc.exe on 64bit with some versions look in the wrong path
-    #   location when building postgresql.   This cheats by copying the x64 bit
-    #   files to that location.
-    - IF "%PYTHON_ARCH%"=="64" (COPY /Y "C:\\Program Files\\Microsoft SDKs\\Windows\\v7.0\\Bin\\x64\\rc*" "C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v7.0A\\Bin")
-
-    # Define the PostgreSQL DATA directory location
-    - SET POSTGRESQL_DATA_DIR=C:\Program Files\PostgreSQL\9.6\data
-    # Define the Appveyor installed OpenSSL Binary Path
-    - SET INSTALLED_OPENSSL=C:\OpenSSL-v111-Win64\bin
-
-    # Change PostgreSQL config before service starts to allow > 1 prepared
-    #   transactions for test cases
-    - ECHO max_prepared_transactions = 10 >> "%POSTGRESQL_DATA_DIR%\\postgresql.conf"
-
-    # Have the local PostgreSQL server only allow SSL connections
-    - ECHO ssl = on >> "%POSTGRESQL_DATA_DIR%\\postgresql.conf"
-    - CD %POSTGRESQL_DATA_DIR%
-    - "%INSTALLED_OPENSSL%\\openssl req -new -x509 -days 365 -nodes -text -out server.crt -keyout server.key -subj \"/CN=initd.org\""
-    - "%INSTALLED_OPENSSL%\\openssl req -new -nodes -text -out root.csr -keyout root.key -subj \"/CN=initd.org\""
-    - "%INSTALLED_OPENSSL%\\openssl x509 -req -in root.csr -text -days 3650 -extensions v3_ca -signkey root.key -out root.crt"
-    - "%INSTALLED_OPENSSL%\\openssl req -new -nodes -text -out server.csr -keyout server.key -subj \"/CN=initd.org\""
-    - "%INSTALLED_OPENSSL%\\openssl x509 -req -in server.csr -text -days 365 -CA root.crt -CAkey root.key -CAcreateserial -out server.crt"
-
-    # Return to the build folder so that the git cloning functions correctly
-    - CD %APPVEYOR_BUILD_FOLDER%
+# init:
 
 # Repository gets cloned, Cache is restored
+
 install:
-    # We start off CD'ed to cloned folder
-    - SET BASE_DIR=C:\Others\%PYTHON_ARCH%\%VS_VER%
-    - SET BUILD_DIR=%BASE_DIR%\Builds
-    - IF NOT EXIST %BUILD_DIR% MKDIR %BUILD_DIR%
+    # Update the psycopg2 submodule
+    - git submodule update --init --recursive
+    - "%PYEXE% psycopg2\\scripts\\appveyor.py install"
 
-    - ECHO *******************************************************************
-    - ECHO Initialized variables specific for this build
-    - ECHO *******************************************************************
-    - ECHO %BASE_DIR%
-    - ECHO %BUILD_DIR%
-    - ECHO *******************************************************************
-
-    # Setup directories for building OpenSSL libraries
-    - ECHO *******************************************************************
-    - ECHO Preparing for building OpenSSL
-    - ECHO *******************************************************************
-    - SET OPENSSLTOP=%BASE_DIR%\openssl
-    - IF NOT EXIST %OPENSSLTOP%\include\openssl MKDIR %OPENSSLTOP%\include\openssl
-    - IF NOT EXIST %OPENSSLTOP%\lib MKDIR %OPENSSLTOP%\lib
-
-    # Setup OpenSSL Environment Variables based on processor architecture
-    - ps: >-
-        If ($env:PYTHON_ARCH -Match "32" ) {
-            $env:VCVARS_PLATFORM="x86"
-            $env:TARGET="VC-WIN32"
-        } Else {
-            $env:VCVARS_PLATFORM="amd64"
-            $env:TARGET="VC-WIN64A"
-            $env:CPU="AMD64"
-        }
-    # Download OpenSSL source
-    - CD C:\Others
-    - IF NOT EXIST OpenSSL_%OPENSSL_VERSION%.zip (
-        curl -fsSL -o OpenSSL_%OPENSSL_VERSION%.zip https://github.com/openssl/openssl/archive/OpenSSL_%OPENSSL_VERSION%.zip
-      )
-
-    # OpenSSL >= 1.1.0 has different library names from 1.0.x
-    # 1.0.x name -> 1.1.x name
-    # libeay32 -> libcrypto
-    # ssleay32 -> libssl
-    - IF NOT EXIST %OPENSSLTOP%\lib\libssl.lib (
-        CD %BUILD_DIR% &&
-        7z x C:\Others\OpenSSL_%OPENSSL_VERSION%.zip &&
-        CD openssl-OpenSSL_%OPENSSL_VERSION% &&
-        perl Configure %TARGET% no-asm no-shared no-zlib --prefix=%OPENSSLTOP% --openssldir=%OPENSSLTOP% &&
-        nmake build_libs install_dev &&
-        CD %BASE_DIR% &&
-        RMDIR /S /Q %BUILD_DIR%\openssl-OpenSSL_%OPENSSL_VERSION%
-      )
-
-    # Setup directories for building PostgreSQL librarires
-    - ECHO *******************************************************************
-    - ECHO Preparing for building PostgreSQL libraries
-    - ECHO *******************************************************************
-    - SET PGTOP=%BASE_DIR%\postgresql
-    - IF NOT EXIST %PGTOP%\include MKDIR %PGTOP%\include
-    - IF NOT EXIST %PGTOP%\lib MKDIR %PGTOP%\lib
-    - IF NOT EXIST %PGTOP%\bin MKDIR %PGTOP%\bin
-
-    # Download PostgreSQL source
-    - CD C:\Others
-    - IF NOT EXIST postgres-REL_%POSTGRES_VERSION%.zip (
-        curl -fsSL -o postgres-REL_%POSTGRES_VERSION%.zip https://github.com/postgres/postgres/archive/REL_%POSTGRES_VERSION%.zip
-      )
-
-    # Setup build config file (config.pl)
-    # Hack the Mkvcbuild.pm file so we build the lib version of libpq
-    # Build libpgport, libpgcommon, libpq
-    # Install includes
-    # Copy over built libraries
-    # Prepare local include directory for building from
-    # Build pg_config in place
-    # Note ECHOs for OpenSSL 1.1 configuration (pg_config.h.win32). See: 
-    # https://www.postgresql-archive.org/Compile-psql-9-6-with-SSL-Version-1-1-0-td6054118.html
-    # NOTE: Cannot set and use the same variable inside an IF
-    - SET PGBUILD=%BUILD_DIR%\postgres-REL_%POSTGRES_VERSION%
-    - IF NOT EXIST %PGTOP%\lib\libpq.lib (
-        CD %BUILD_DIR% &&
-        7z x C:\Others\postgres-REL_%POSTGRES_VERSION%.zip &&
-        CD postgres-REL_%POSTGRES_VERSION% &&
-        ECHO '#define HAVE_ASN1_STRING_GET0_DATA 1' >> src\include\pg_config.h.win32 &&
-        ECHO '#define HAVE_BIO_GET_DATA 1' >> src\include\pg_config.h.win32 &&
-        ECHO '#define HAVE_BIO_METH_NEW 1' >> src\include\pg_config.h.win32 &&
-        ECHO '#define HAVE_OPENSSL_INIT_SSL 1' >> src\include\pg_config.h.win32 &&
-        perl -pi.bak -e "s/'//g" src\include\pg_config.h.win32 &&
-        CD src\tools\msvc &&
-        ECHO $config-^>{ldap} = 0; > config.pl &&
-        ECHO $config-^>{openssl} = "%OPENSSLTOP:\=\\%"; >> config.pl &&
-        ECHO.>> config.pl &&
-        ECHO 1;>> config.pl &&
-        perl -pi.bak -e "s/'libpq', 'dll'/'libpq', 'lib'/g" Mkvcbuild.pm &&
-        build libpgport &&
-        build libpgcommon &&
-        build libpq &&
-        ECHO "" > %PGBUILD%\src\backend\parser\gram.h &&
-        perl -pi.bak -e "s/qw\(Install\)/qw\(Install CopyIncludeFiles\)/g" Install.pm &&
-        perl -MInstall=CopyIncludeFiles -e"chdir('../../..'); CopyIncludeFiles('%PGTOP%')" &&
-        COPY %PGBUILD%\Release\libpgport\libpgport.lib %PGTOP%\lib &&
-        COPY %PGBUILD%\Release\libpgcommon\libpgcommon.lib %PGTOP%\lib &&
-        COPY %PGBUILD%\Release\libpq\libpq.lib %PGTOP%\lib &&
-        XCOPY /Y /S %PGBUILD%\src\include\port\win32\* %PGBUILD%\src\include &&
-        XCOPY /Y /S %PGBUILD%\src\include\port\win32_msvc\* %PGBUILD%\src\include &&
-        CD %PGBUILD%\src\bin\pg_config &&
-        cl pg_config.c /MT /nologo /I%PGBUILD%\src\include /link /LIBPATH:%PGTOP%\lib libpgcommon.lib libpgport.lib advapi32.lib /NODEFAULTLIB:libcmt.lib /OUT:%PGTOP%\bin\pg_config.exe &&
-        CD %BASE_DIR% &&
-        RMDIR /S /Q %PGBUILD%
-      )
-
-    # We need pip current and wheel installed to build wheels
-    - "%PYTHON%\\python.exe -m pip install --upgrade pip"
-    - "%PYTHON%\\python.exe -m pip install wheel"
-
+# PostgreSQL server starts now
 
 build: off
 
-#before_build:
-
 build_script:
-    # Add PostgreSQL binaries to the path
-    - PATH=C:\Program Files\PostgreSQL\9.6\bin\;%PATH%
-    - CD C:\Project
+    - "%PYEXE% psycopg2\\scripts\\appveyor.py build_script"
 
-    # Update the psycopg2 submodule
-    - git submodule update --init --recursive
-
-    - CD C:\Project\psycopg2
-    - ps: $env:PYVERDIR = (Select-String setup.py -pattern "^PSYCOPG_VERSION = '(.*)'").Matches.Groups[1].Value
-    - ps: $env:DISTDIR = "C:\\Project\\psycopg2\\dist\\psycopg2-" + $env:PYVERDIR
-
-    # Replace the name of the package with what desired
-    - ps: (Get-Content -Path "setup.py") -replace
-        'setup\(name="psycopg2"', "setup(name=""$env:CONFIGURATION""" |
-        Set-Content "setup.py"
-
-    - "%PYTHON%\\python.exe setup.py build_ext --have-ssl --pg-config %PGTOP%\\bin\\pg_config.exe -l libpgcommon -l libpgport -L %OPENSSLTOP%\\lib -I %OPENSSLTOP%\\include"
-    - IF "%CONFIGURATION%"=="psycopg2" %PYTHON%\\python.exe setup.py bdist_wininst -d %DISTDIR%
-    - "%PYTHON%\\python.exe setup.py bdist_wheel -d %DISTDIR%"
-
-#after_build:
+after_build:
+    - "%PYEXE% psycopg2\\scripts\\appveyor.py after_build"
 
 before_test:
-    # Create and setup PostgreSQL database for the tests
-    - createdb %PSYCOPG2_TESTDB%
+    - "%PYEXE% psycopg2\\scripts\\appveyor.py before_test"
 
 test_script:
-    - "%PYTHON%/Scripts/pip.exe --version"
-    - "%PYTHON%/Scripts/pip.exe install --no-index -f %DISTDIR% %CONFIGURATION%"
+    - "%PYEXE% psycopg2\\scripts\\appveyor.py test_script"
 
-    # Print psycopg and libpq versions
-    - "%PYTHON%\\python.exe -c \"import psycopg2; print(psycopg2.__version__)\""
-    - "%PYTHON%\\python.exe -c \"import psycopg2; print(psycopg2.__libpq_version__)\""
-    - "%PYTHON%\\python.exe -c \"import psycopg2; print(psycopg2.extensions.libpq_version())\""
+on_success:
+    - "%PYEXE% psycopg2\\scripts\\appveyor.py on_success"
 
-    # fail if we are not using the expected libpq library
-    - "%PYTHON%\\python.exe -c \"import os, sys, psycopg2; sys.exit(int(os.environ['WANT_LIBPQ']) != psycopg2.extensions.libpq_version())\""
-
-    # Unset the OPENSSL_CONF variable for our tests
-    - ps: Remove-Item Env:\OPENSSL_CONF
-
-    - ps: $env:PSYCOPG2_TEST_FAST = "1"
-    - "%PYTHON%\\python.exe -c \"import tests; tests.unittest.main(defaultTest='tests.test_suite')\""
+# Cache is saved after ending of on_success
 
 artifacts:
-    - path: psycopg2\dist\psycopg2-$(PYVERDIR)\*.whl
+    - path: psycopg2\dist\psycopg2-*\*.whl
       name: wheel
-    - path: psycopg2\dist\psycopg2-$(PYVERDIR)\*.exe
+    - path: psycopg2\dist\psycopg2-*\*.exe
       name: exe
 
 deploy: off
-#before_deploy: # Script
-#deploy_script:
-#after_deploy: #Script
-
-#deployment_success: # Webhooks
-on_success: # Script
-#  You can use this step to upload your artifacts to a public website.
-#  See Appveyor's documentation for more details. Or you can simply
-#  access your wheels from the Appveyor "artifacts" tab for your build.
-    - ECHO "Starting Artifact Deployment"
-    - CD C:\Project\psycopg2
-
-    - ECHO SHA1 Hashes
-    - ECHO ====================================================================
-    - CD dist
-    - sha1sum -b psycopg2-%PYVERDIR%/*
-    - CD ..
-
-    # If we are not on the psycopg AppVeyor account, the environment variable
-    # REMOTE_KEY will not be decrypted and therefor undefined.  Define it with
-    # a string so that we do not get errors when building outside the psycopg
-    # account
-    - ps: If (-not (Test-Path env:REMOTE_KEY)) { $env:REMOTE_KEY = 'empty' }
 
 
-    # Insert SSH Private Key from environment variable
-    - ps: $fileContent = "-----BEGIN RSA PRIVATE KEY-----`n"
-    - ps: $fileContent += $env:REMOTE_KEY.Replace(" ", "`n")
-    - ps: $fileContent += "`n-----END RSA PRIVATE KEY-----`n"
-    - ps: Set-Content C:\Project\id_rsa $fileContent
-
-    # Make a directory to please MinGW's version of ssh
-    - MKDIR C:\MinGW\msys\1.0\home\appveyor\.ssh
-    # Only upload if the computer is 'online' and being built by the psycopg
-    # AppVeyor account
-    - ps: If (($env:APPVEYOR_ACCOUNT_NAME -eq "psycopg") -and (Test-Connection -ComputerName initd.org -Count 1 -Quiet)) { C:\MinGW\msys\1.0\bin\rsync -avr -e "C:\\MinGW\\msys\\1.0\\bin\\ssh -i C:\\Project\\id_rsa -o UserKnownHostsFile=C:\\Project\\known_hosts" "dist/" "upload@initd.org:" }
-# Cache is saved after ending of on_success
-
-#build_failure: # Webhooks
-#deployment_failure: # Webhooks
-#on_failure: # Script
-
-
-# Uncomment to enable RDP on build finish
-on_finish:
-  #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# vim: set ts=4 sts=4 sw=4:


### PR DESCRIPTION
The other half of the story. The appveyor file to build binaries is very similar to the one used for tests. It uses the same script from the psycopg2 submodule; the script takes care about some differences.

Note that I've dropped the uncomfortable step running before repos cloning, shuffling things a bit across the different steps.