### PR TITLE
Changes to support building Py3.9 in AppVeyor and updated OpenSSL to 1.1.1h

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,9 @@ environment:
     PGPASSWORD: Password12!
     PGSSLMODE: require
 
+    # Add CWD to perl library path for PostgreSQL build on VS2019
+    PERL5LIB: .
+
     # Select according to the service enabled
     POSTGRES_DIR: C:\Program Files\PostgreSQL\9.6\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ environment:
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "34", PY_ARCH: "32"}
         - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "34", PY_ARCH: "64"}
 
-    OPENSSL_VERSION: "1_1_1g"
+    OPENSSL_VERSION: "1_1_1h"
     POSTGRES_VERSION: "11_4"
 
     PSYCOPG2_TESTDB: psycopg2_test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,20 +16,18 @@ environment:
     matrix:
         # For Python versions available on Appveyor, see
         # https://www.appveyor.com/docs/build-environment/
-      - {PY_VER: "27", PY_ARCH: "32"}
-      - {PY_VER: "27", PY_ARCH: "64"}
-      - {PY_VER: "39", PY_ARCH: "32"}
-      - {PY_VER: "39", PY_ARCH: "64"}
-      - {PY_VER: "38", PY_ARCH: "32"}
-      - {PY_VER: "38", PY_ARCH: "64"}
-      - {PY_VER: "37", PY_ARCH: "32"}
-      - {PY_VER: "37", PY_ARCH: "64"}
-      - {PY_VER: "36", PY_ARCH: "32"}
-      - {PY_VER: "36", PY_ARCH: "64"}
-      - {PY_VER: "35", PY_ARCH: "32"}
-      - {PY_VER: "35", PY_ARCH: "64"}
-      - {PY_VER: "34", PY_ARCH: "32"}
-      - {PY_VER: "34", PY_ARCH: "64"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "39", PY_ARCH: "32"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019, PY_VER: "39", PY_ARCH: "64"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "38", PY_ARCH: "32"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "38", PY_ARCH: "64"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "37", PY_ARCH: "32"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "37", PY_ARCH: "64"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "36", PY_ARCH: "32"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "36", PY_ARCH: "64"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "35", PY_ARCH: "32"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "35", PY_ARCH: "64"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "34", PY_ARCH: "32"}
+        - {APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015, PY_VER: "34", PY_ARCH: "64"}
 
     OPENSSL_VERSION: "1_1_1g"
     POSTGRES_VERSION: "11_4"

--- a/data/appveyor.cache_rebuild
+++ b/data/appveyor.cache_rebuild
@@ -8,7 +8,7 @@ To invalidate the cache, update this file and check it into git.
 Currently used modules built in the cache:
 
 OpenSSL
-        Version: 1.1.1g
+        Version: 1.1.1h
 
 PostgreSQL
         Version: 11.5


### PR DESCRIPTION
Setup the Python versions with the appropriate AppVeyor build images, updated OpenSSL to 1.1.1h, and add current working directory to the perl library path to fix build issues with the VS 2019 image and Postgres.